### PR TITLE
Update ImageIn.cpp - fix warning

### DIFF
--- a/src/ImageIn.cpp
+++ b/src/ImageIn.cpp
@@ -33,7 +33,7 @@ struct ImageIn : Module {
 	unsigned int width = 0;
 	unsigned int height = 0;
 	int image = 0;
-	char* filename = "";
+	char* filename {};
 
 	ImageIn() {
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);


### PR DESCRIPTION
```
src/ImageIn.cpp:36:26: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings] 
   36 |         char* filename = "";                                                                      
      |                          ^~
```